### PR TITLE
fix: Truncate runedates in calculations

### DIFF
--- a/source/jewels.ts
+++ b/source/jewels.ts
@@ -15,7 +15,7 @@ export enum Jewel {
  * @returns The accessible jewel.
  */
 export function jewel(timestamp: number): Jewel | null {
-	const slot = nextInt(BigInt(runedate(timestamp)) * 2n ** 32n, 5n);
+	const slot = nextInt(BigInt(Math.trunc(runedate(timestamp))) * 2n ** 32n, 5n);
 
 	switch (slot) {
 		case 0n:

--- a/source/travelling-merchant.ts
+++ b/source/travelling-merchant.ts
@@ -91,7 +91,7 @@ const SLOTS = {
  */
 function getSlots(runedate: number, n1: number, n2: bigint) {
 	const seed = runedate * 2 ** 32 + (runedate % n1);
-	return nextInt(BigInt(seed), n2);
+	return nextInt(BigInt(Math.trunc(seed)), n2);
 }
 
 /**


### PR DESCRIPTION
This was causing an error for `BigInt` conversions.